### PR TITLE
Adicionando aos services a CorsPolicy que assim retira restrição de e…

### DIFF
--- a/ExcelToDatabase/Program.cs
+++ b/ExcelToDatabase/Program.cs
@@ -1,3 +1,4 @@
+using Aspose.Cells.Charts;
 using ExcelToDatabase.Data;
 using ExcelToDatabase.Facade;
 using ExcelToDatabase.Facade.Interface;
@@ -16,6 +17,10 @@ builder.Services.AddControllers();
 // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
+builder.Services.AddCors(options =>
+{
+    options.AddPolicy("CorsPolicy", builder => builder.AllowAnyOrigin().AllowAnyMethod().AllowAnyHeader());
+});
 var sqlConnect = builder.Configuration.GetSection("sqlConnection").Get<SqlConnect>();
 builder.Services.AddDbContext<DBDataContext>(options => options.UseSqlServer(sqlConnect.ConnectionString));
 builder.Services.AddScoped<IBDrepository, BDrepository>();
@@ -32,7 +37,7 @@ if (app.Environment.IsDevelopment())
 }
 
 app.UseHttpsRedirection();
-
+app.UseCors("CorsPolicy");
 app.UseAuthorization();
 
 app.MapControllers();

--- a/ExcelToDatabase/Services/ExcelServices.cs
+++ b/ExcelToDatabase/Services/ExcelServices.cs
@@ -45,7 +45,6 @@ namespace ExcelToDatabase.Services
             using(var excel = new ExcelPackage())
             {
                 var worksheet = excel.Workbook.Worksheets.Add("Product stock");
-
                 worksheet.TabColor = System.Drawing.Color.Green;
                 worksheet.DefaultRowHeight = 12;
                 worksheet.Rows.Style.HorizontalAlignment = OfficeOpenXml.Style.ExcelHorizontalAlignment.Center;


### PR DESCRIPTION
Desabilitando a proteção do Corspolicy consigo utilizar os enpoints locais nas duas aplicações para hospedagem do projeto, me permitindo rodar o front end no localhost e hospedar e consumir o back end tbm no localhost.